### PR TITLE
#Pipeline/563 배포대상 kubernetes 연결 테스트 비동기로 변경

### DIFF
--- a/ko/release-notes.md
+++ b/ko/release-notes.md
@@ -1,7 +1,7 @@
 ## Dev Tools > Pipeline > 릴리스 노트
 
 ### 2022. 10. 25.
-* 배포 대상 Kubernetes 연결 테스트 시간 초과시에도 안내메시지를 노출 하도록 수정하였습니다.
+* 배포 대상 Kubernetes 연결 테스트 시간 초과 시에도 안내 메시지를 노출하도록 수정하였습니다.
 
 ### 2022. 08. 23.
 * 스테이지가 없는 Pipeline을 [API](https://docs.toast.com/ko/Dev%20Tools/Pipeline/ko/api-guide/#pipeline)로 실행 시 실패 응답을 주도록 수정하였습니다.

--- a/ko/release-notes.md
+++ b/ko/release-notes.md
@@ -1,7 +1,7 @@
 ## Dev Tools > Pipeline > 릴리스 노트
 
 ### 2022. 10. 25.
-* 배포 대상 kubernetes 연결 테스트가 비동기 방식으로 변경되었습니다.
+* 배포 대상 Kubernetes 연결 테스트 시간 초과시에도 안내메시지를 노출 하도록 수정하였습니다.
 
 ### 2022. 08. 23.
 * 스테이지가 없는 Pipeline을 [API](https://docs.toast.com/ko/Dev%20Tools/Pipeline/ko/api-guide/#pipeline)로 실행 시 실패 응답을 주도록 수정하였습니다.


### PR DESCRIPTION
 - 기술회의 피드백 반영