### PR TITLE
#Pipeline/563 배포대상 kubernetes 연결 테스트 비동기로 변경

### DIFF
--- a/zh/release-notes.md
+++ b/zh/release-notes.md
@@ -1,5 +1,8 @@
 ## Dev Tools > Pipeline > Release Notes
 
+### October 25, 2022
+* Modified to display a guide message when the kubernetes integration test in deployment target times out.
+
 ### August 23, 2022
 * Made modifications so that, when running a pipeline without stages through the [API](https://docs.toast.com/en/Dev%20Tools/Pipeline/en/api-guide/#pipeline), a failure response is returned.
 


### PR DESCRIPTION
 - 중국 릴리즈 노트 추가